### PR TITLE
Fix: Correlations API 결과 Cache 및 후처리

### DIFF
--- a/src/main/java/swm/thlee/linked_paper_api_server/client/PaperApiClient.java
+++ b/src/main/java/swm/thlee/linked_paper_api_server/client/PaperApiClient.java
@@ -78,7 +78,11 @@ public class PaperApiClient {
     return mapToSearchPaperResult(apiResponses);
   }
 
-  public SearchPaperResult corelatedPapers(
+  @Cacheable(
+      value = "correlatedResults",
+      key =
+          "#paperID + (T(org.springframework.util.CollectionUtils).isEmpty(#filterCategories) ? '' : T(String).join(',', #filterCategories)) + (#filterStartDate == null ? '' : #filterStartDate) + (#filterEndDate == null ? '' : #filterEndDate)")
+  public SearchPaperResult correlatedPapers(
       String paperID,
       int limit,
       List<String> filterCategories,

--- a/src/main/java/swm/thlee/linked_paper_api_server/controller/SearchController.java
+++ b/src/main/java/swm/thlee/linked_paper_api_server/controller/SearchController.java
@@ -44,7 +44,7 @@ public class SearchController {
   @GetMapping
   public ResponseEntity<SearchPaperResult> findCorrelationResult(
       @PathVariable("paperID") String paperID,
-      @RequestParam(value = "limit", defaultValue = "20") int limit,
+      @RequestParam(value = "limit", defaultValue = "10") int limit,
       @RequestParam(value = "filter_tag", required = false) List<String> filterTags,
       @RequestParam(value = "filter_category", required = false) List<String> filterCategories,
       @RequestParam(value = "filter_journal", required = false) List<String> filterJournal,

--- a/src/main/java/swm/thlee/linked_paper_api_server/service/SearchService.java
+++ b/src/main/java/swm/thlee/linked_paper_api_server/service/SearchService.java
@@ -41,8 +41,12 @@ public class SearchService {
       List<String> filterJournal,
       String filterStartDate,
       String filterEndDate) {
-    return paperApiClient.corelatedPapers(
-        paperID, limit, filterCategories, filterStartDate, filterEndDate);
+
+    SearchPaperResult externalResult =
+        paperApiClient.correlatedPapers(
+            paperID, limit, filterCategories, filterStartDate, filterEndDate);
+
+    return processSearchResults(externalResult, "similarity", limit, 0, false);
   }
 
   private SearchPaperResult processSearchResults(


### PR DESCRIPTION
## Why need this PR❓
Search Server API 변경으로, API server result 후처리 및 cache 추가

## Changes ✌️
- 기본 limit params 10으로 고정
- search server result cache

## Screenshoot 🌅 (optional)
![image](https://github.com/user-attachments/assets/60bcb0b9-16d0-430c-b086-fdf89db3cd14)
