### PR TITLE
feat: semantic api call 로직 개선

### DIFF
--- a/src/main/java/swm/thlee/linked_paper_api_server/client/PaperApiClient.java
+++ b/src/main/java/swm/thlee/linked_paper_api_server/client/PaperApiClient.java
@@ -9,6 +9,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
@@ -22,6 +23,7 @@ import swm.thlee.linked_paper_api_server.model.Paper;
 public class PaperApiClient {
 
   private final WebClient webClient;
+  @Autowired private SemanticApiClient semanticApiClient;
 
   // 생성자에서 외부 API URL을 받아오고 WebClient를 설정
   public PaperApiClient(
@@ -122,7 +124,11 @@ public class PaperApiClient {
         List.of(searchApiRespons).stream().map(this::mapToPaper).collect(Collectors.toList());
 
     searchResult.setData(papers);
-    return searchResult;
+    return aggregateExtraInfo(searchResult);
+  }
+
+  private SearchPaperResult aggregateExtraInfo(SearchPaperResult searchResult) {
+    return semanticApiClient.getExtrainfo(searchResult);
   }
 
   // ApiResponse를 Paper 객체로 변환하는 메소드

--- a/src/main/java/swm/thlee/linked_paper_api_server/service/SearchService.java
+++ b/src/main/java/swm/thlee/linked_paper_api_server/service/SearchService.java
@@ -6,7 +6,6 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import swm.thlee.linked_paper_api_server.client.PaperApiClient;
-import swm.thlee.linked_paper_api_server.client.SemanticApiClient;
 import swm.thlee.linked_paper_api_server.dto.SearchPaperResult;
 import swm.thlee.linked_paper_api_server.model.Paper;
 
@@ -14,7 +13,6 @@ import swm.thlee.linked_paper_api_server.model.Paper;
 public class SearchService {
 
   @Autowired private PaperApiClient paperApiClient;
-  @Autowired private SemanticApiClient semanticApiClient;
 
   public SearchPaperResult searchPapers(
       String query,
@@ -31,10 +29,8 @@ public class SearchService {
     SearchPaperResult externalSearchResult =
         paperApiClient.searchPapers(query, filterCategories, filterStartDate, filterEndDate);
 
-    SearchPaperResult aggregatedResult = semanticApiClient.getExtrainfo(externalSearchResult);
-
     // 유사성 제한, 정렬 및 인덱싱은 캐싱된 데이터에서 처리
-    return processSearchResults(aggregatedResult, sorting, size, index, similarityLimit);
+    return processSearchResults(externalSearchResult, sorting, size, index, similarityLimit);
   }
 
   public SearchPaperResult findCorrelatedPapers(
@@ -50,9 +46,7 @@ public class SearchService {
         paperApiClient.correlatedPapers(
             paperID, limit, filterCategories, filterStartDate, filterEndDate);
 
-    SearchPaperResult aggregatedResult = semanticApiClient.getExtrainfo(externalSimilarResult);
-
-    return processSearchResults(aggregatedResult, "similarity", limit, 0, false);
+    return processSearchResults(externalSimilarResult, "similarity", limit, 0, false);
   }
 
   private SearchPaperResult processSearchResults(

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -22,3 +22,7 @@ search-service-api:
 logging:
   level:
     org.springframework.web: DEBUG  # WebClient 요청 로깅
+
+sentry:
+  dsn: ""  # Sentry DSN을 비워둠
+  enabled: false  # Sentry 비활성화


### PR DESCRIPTION
## Why need this PR❓
- 기존 매 reqeust마다 semantic api call하던 로직 개선

## Changes ✌️
AS-IS
request -> search server (caching) -> semantic api call -> response

TO-BE
request -> search server + semantic api call (caching) -> response

- 검색 결과 추가 로딩 및 graph view에서 성능 향상
## Screenshoot 🌅 (optional)
